### PR TITLE
Now bundling a non-minified browser version as well (using rollup@^0.43.0)

### DIFF
--- a/bundle-rollup.config.js
+++ b/bundle-rollup.config.js
@@ -4,15 +4,25 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 import buble from 'rollup-plugin-buble';
 import uglify from 'rollup-plugin-uglify';
 
-export default {
+const configNonMinified = {
 	entry: './browser.js',
 	plugins: [
 		nodeResolve(),
-		buble(),
-		uglify()
+		buble()
 	],
 	moduleName: 'emmetCodeMirrorPlugin',
 	format: 'umd',
 	dest: 'dist/emmet-codemirror-plugin.js',
 	sourceMap: 'dist/emmet-codemirror-plugin.js.map'
 };
+
+const configMinified = Object.assign({}, configNonMinified);
+configMinified.plugins = configMinified.plugins.concat(uglify());
+configMinified.dest = 'dist/emmet-codemirror-plugin.min.js';
+configMinified.sourceMap = 'dist/emmet-codemirror-plugin.min.js.map';
+
+// Exporting multiple configs. Reference: https://github.com/rollup/rollupjs.org/blob/922d6abdffaa9584df88e5444529d917144c01f3/rollup.config.js
+export default [
+	configNonMinified,
+	configMinified
+];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "devDependencies": {
     "codemirror": "^5.25.2",
-    "rollup": "^0.41.6",
+    "rollup": "^0.43.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-uglify": "^1.0.2",


### PR DESCRIPTION
For debugging purposes (where sourcemap can't be used), a non-minified browser version is helpful.

Kindly consider this PR which adds a nearly identical rollup config, without the uglify part.

I wish to use this codemirror plugin in the browser extension https://github.com/webextensions/live-css-editor and my use case is as follows:
- I wish to avoid using sourcemap files to reduce the byte size of the extension. And the uglified version isn't much helpful for debuggability. So, the non-minified version provides good balance.
- **Apart from that, unobfuscated code in a browser extension has faster and better chance of approval.**

Thanks in advance :-)